### PR TITLE
new/delete instead of malloc/free && char* instead of char[1]

### DIFF
--- a/nas.cc
+++ b/nas.cc
@@ -17,25 +17,30 @@ extern "C" void init (Handle<Object>);
 struct simple_request {
   int x;
   int y;
+  char *name;
   Persistent<Function> cb;
-  // maybe it matters to put the char[] last?  not sure.
-  char name[1];
 };
 
 static Handle<Value> DoSomethingAsync (const Arguments& args) {
   HandleScope scope;
   const char *usage = "usage: doSomething(x, y, name, cb)";
+  
+  // validate argument count
   if (args.Length() != 4) {
     return ThrowException(Exception::Error(String::New(usage)));
   }
+  
+  // read arguments
   int x = args[0]->Int32Value();
   int y = args[1]->Int32Value();
   String::Utf8Value name(args[2]);
   Local<Function> cb = Local<Function>::Cast(args[3]);
 
-  simple_request *sr = (simple_request *)
-    malloc(sizeof(struct simple_request) + name.length() + 1);
+  // init request
+  simple_request *sr = new simple_request();
+  sr->name = new char[name.length() + 1];
 
+  // assign arguments to request fields
   sr->cb = Persistent<Function>::New(cb);
   strncpy(sr->name, *name, name.length() + 1);
   sr->x = x;
@@ -58,18 +63,26 @@ static int DoSomething (eio_req *req) {
 static int DoSomething_After (eio_req *req) {
   HandleScope scope;
   ev_unref(EV_DEFAULT_UC);
+  
   struct simple_request * sr = (struct simple_request *)req->data;
+  
   Local<Value> argv[3];
   argv[0] = Local<Value>::New(Null());
   argv[1] = Integer::New(req->result);
   argv[2] = String::New(sr->name);
+  
+  //call callback
   TryCatch try_catch;
   sr->cb->Call(Context::GetCurrent()->Global(), 3, argv);
   if (try_catch.HasCaught()) {
     FatalException(try_catch);
   }
+  
+  // cleanup
   sr->cb.Dispose();
-  free(sr);
+  delete[] sr->name;
+  delete sr;
+  
   return 0;
 }
 


### PR DESCRIPTION
make use of new/delete, omit malloc/free. Use char\* instead of char[1] and get rid of size hack and alignment issues. Some doc added.

Can't test for memory leaks becouse node itself pollutes valgrind output, sorry.
